### PR TITLE
This commit updates the following:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.28...3.30)
+cmake_minimum_required(VERSION 3.30...3.32)
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/common/bootstrap.cmake" NO_POLICY_SCOPE)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,7 +2,7 @@
   "version": 8,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 28,
+    "minor": 30,
     "patch": 0
   },
   "configurePresets": [

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ The plugin template is meant to be used as a starting point for OBS Studio plugi
 
 | Platform  | Tool   |
 |-----------|--------|
-| Windows   | Visal Studio 17 2022 |
-| macOS     | XCode 16.0 |
-| Windows, macOS  | CMake 3.30.5 |
-| Ubuntu 24.04 | CMake 3.28.3 |
+| Windows   | Visual Studio 17 2022 |
+| macOS     | Xcode 16.1 |
+| Windows, macOS  | CMake 3.30.0 |
+| Ubuntu 24.04 | CMake 3.30.0 |
 | Ubuntu 24.04 | `ninja-build` |
-| Ubuntu 24.04 | `pkg-config`
+| Ubuntu 24.04 | `pkg-config` |
 | Ubuntu 24.04 | `build-essential` |
 
 ## Quick Start

--- a/buildspec.json
+++ b/buildspec.json
@@ -10,24 +10,24 @@
             }
         },
         "prebuilt": {
-            "version": "2025-07-11",
+            "version": "2025-05-23",
             "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
             "label": "Pre-Built obs-deps",
             "hashes": {
-                "macos": "495687e63383d1a287684b6e2e9bfe246bb8f156fe265926afb1a325af1edd2a",
-                "windows-x64": "c8c642c1070dc31ce9a0f1e4cef5bb992f4bff4882255788b5da12129e85caa7"
+                "macos": "7b1448581b92c6f8d4e2f9b1b10eb318ebfc4df7255638e05bacb49b620e190d",
+                "windows-x64": "88dc7bab50542b4b58194cdd5d7e6f4b73cde7c0d1ee7a040a6d9c9df05187b1"
             }
         },
         "qt6": {
-            "version": "2025-07-11",
+            "version": "2025-05-23",
             "baseUrl": "https://github.com/obsproject/obs-deps/releases/download",
             "label": "Pre-Built Qt6",
             "hashes": {
-                "macos": "d3f5f04b6ea486e032530bdf0187cbda9a54e0a49621a4c8ba984c5023998867",
-                "windows-x64": "0e76bf0555dd5382838850b748d3dcfab44a1e1058441309ab54e1a65b156d0a"
+                "macos": "d4945fe719d31d353dc76298f58823d7891126e33af5029f763427ea9f80bfaa",
+                "windows-x64": "bd80383dc799c0bba2f7fae793613b3fbd2cc3a3712b3d3b63b490721d187d9e"
             },
             "debugSymbols": {
-                "windows-x64": "11b7be92cf66a273299b8f3515c07a5cfb61614b59a4e67f7fc5ecba5e2bdf21"
+                "windows-x64": "9c9a15c5dbe59eb6a1c31c06b7208f3c4403671fbdfaef341cac3beb7af24ea1"
             }
         }
     },


### PR DESCRIPTION
- `obs-studio` to version 31.1.1
- `obs-deps` and `qt6` to version 2025-05-23
- Minimum required CMake version to 3.30